### PR TITLE
use the links mechanism dns entries in the /etc/hosts file to define the...

### DIFF
--- a/default
+++ b/default
@@ -1,9 +1,9 @@
 upstream docker-registry {
-  server REGISTRY_IP:5000;
+  server registry:5000;
 }
 
 upstream docker-index {
-  server INDEX_IP:5100;
+  server index:5100;
 }
 
 server {

--- a/run.sh
+++ b/run.sh
@@ -5,9 +5,6 @@ if [ "$REGISTRY_HOSTNAME" = "" ] || [ "$INDEX_HOSTNAME" = "" ]; then
   exit 10
 fi
 
-sed -i "s/REGISTRY_IP/$REGISTRY_PORT_5000_TCP_ADDR/g" /etc/nginx/sites-enabled/default
-sed -i "s/INDEX_IP/$INDEX_PORT_5100_TCP_ADDR/g" /etc/nginx/sites-enabled/default
-
 sed -i "s/REGISTRY_HOSTNAME/$REGISTRY_HOSTNAME/g" /etc/nginx/sites-enabled/default
 sed -i "s/INDEX_HOSTNAME/$INDEX_HOSTNAME/g" /etc/nginx/sites-enabled/default
 


### PR DESCRIPTION
... upstream servers.

using environmental variable+sed works only the first time the container is started, and doesn't survive a reboot, which would change the IP addresses.
the hostnames are only changed the first time as well and the sed command would not do anything later on. The code was left in the run.sh file because it doesn't break anything.
